### PR TITLE
fix: Set MySQL Image version 5.7

### DIFF
--- a/Chapter1/1.3.2 mysql-rc.yaml
+++ b/Chapter1/1.3.2 mysql-rc.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: mysql
+        image: mysql:5.7
         ports:
         - containerPort: 3306
         env:


### PR DESCRIPTION
When we use default MySQL image, the latest version `8.0.x` will get such an error:

```text
Error:com.mysql.jdbc.exceptions.jdbc4.MySQLNonTransientConnectionException: 
Could not create connection to database server.
```

We'd better make it clear that the image version of MySQL is `mysql:5.7` .